### PR TITLE
Warn if version.dll from bootstrapper is present

### DIFF
--- a/openopenlauncher/launch.cpp
+++ b/openopenlauncher/launch.cpp
@@ -57,6 +57,9 @@ bool LaunchWarframe(HWND mainWindow, const std::wstring& wfExePath, const std::w
 	if (!TestForBootstrapperFile(mainWindow, wfDir + L"dwmapi.dll"))
 		return false;
 
+	if (!TestForBootstrapperFile(mainWindow, wfDir + L"version.dll"))
+		return false;
+
 	std::wstring commandLine = wfExePath;
 
 	// wrap in quotation marks in case path contains spaces


### PR DESCRIPTION
Because this is another possible sideloading dll name that can be used.

```
0.10.13

- The Bootstrapper now supports being called version.dll
```